### PR TITLE
feat: enforce auth on task endpoints

### DIFF
--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -1,13 +1,15 @@
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from jose.exceptions import JWTError
+from uuid import UUID
+
 from app.models.user import User
 from app.auth.jwt import get_token_subject
 from app.storage.in_memory import get_user_by_id
-from uuid import UUID
 
 bearer_scheme = HTTPBearer()
 
-def get_current_user(creds: HTTPAuthorizationCredentials = Depends(bearer_scheme)) -> User:
+def get_current_user(creds: HTTPAuthorizationCredentials | None = Depends(bearer_scheme)) -> User:
     """
     Get the current user.
     
@@ -15,15 +17,31 @@ def get_current_user(creds: HTTPAuthorizationCredentials = Depends(bearer_scheme
     - Fetch User by User ID
     - Return User
     """
+    # 1) Missing header (no user is logged in)
+    if creds is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
     token = creds.credentials
-    user_id_str = get_token_subject(token)
+
+    # 2) Bad token
     try:
+        user_id_str = get_token_subject(token)
         user_id = UUID(user_id_str)
-    except ValueError:
-        raise HTTPException(401, "Invalid token")
-    
+    except (JWTError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication token",
+        )
+
+    # 3) Unknown user
     user = get_user_by_id(user_id)
     if not user:
-        raise HTTPException(401, "Invalid token")
-    
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication token",
+        )
+
     return user

--- a/app/auth/jwt.py
+++ b/app/auth/jwt.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta, timezone
 from jose import jwt
-from jose.exceptions import JWTError
 
 # Move to env var later
 SECRET_KEY = "change-me"

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -117,6 +117,7 @@ class TaskUpdate(BaseModel):
 
 class Task(BaseModel):
     id: UUID
+    owner_id: UUID
     title: str = Field(..., min_length=1, max_length=120)
     description: Optional[str] = Field(None, max_length=400)
     status: TaskStatus = TaskStatus.pending

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -1,5 +1,7 @@
-from fastapi import APIRouter, HTTPException, status, Response
+from fastapi import APIRouter, HTTPException, Depends, status
 from app.models.task import Task, TaskCreate, TaskUpdate
+from app.models.user import User
+from app.auth.dependencies import get_current_user
 from app.storage.in_memory import list_tasks, create_task, get_task_by_id, update_task, delete_task
 from uuid import UUID
 import logging
@@ -8,36 +10,36 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 @router.get("", response_model=list[Task])
-def list_tasks_endpoint():
+def list_tasks_endpoint(current_user: User = Depends(get_current_user)):
     """
     Task listing endpoint.
     - Call task listing method
     - Return task list
     """
-    logger.info("Fetching all tasks")
-    return list_tasks()
+    logger.info("Fetching tasks for user_id=%s", str(current_user.id))
+    return list_tasks(user_id=current_user.id)
 
 @router.post("", status_code=status.HTTP_201_CREATED, response_model=Task)
-def create_task_endpoint(data: TaskCreate):
+def create_task_endpoint(data: TaskCreate, current_user: User = Depends(get_current_user)):
     """
     Create new task endpoint.
     - Call task creation method
     - Return task
     """
     logger.info("Creating task with title='%s'", data.title)
-    task = create_task(data)
+    task = create_task(data, user_id=current_user.id)
     logger.info("Task created. id=%s", str(task.id))
     return task
 
 @router.get("/{task_id}", response_model=Task)
-def get_task_by_id_endpoint(task_id: UUID):
+def get_task_by_id_endpoint(task_id: UUID, current_user: User = Depends(get_current_user)):
     """
     Fetch a task by id endpoint.
     - Call task getter method
     - Return task
     """
     logger.info("Fetching task id=%s", str(task_id))
-    task = get_task_by_id(task_id)
+    task = get_task_by_id(task_id, user_id=current_user.id)
     if not task:
         logger.warning("Task not found id=%s", str(task_id))
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
@@ -45,7 +47,7 @@ def get_task_by_id_endpoint(task_id: UUID):
 
 
 @router.patch("/{task_id}", response_model=Task)
-def update_task_endpoint(task_id: UUID, data: TaskUpdate):
+def update_task_endpoint(task_id: UUID, data: TaskUpdate, current_user: User = Depends(get_current_user)):
     """
     Update an existing task endpoint.
     - Call task update endpoint
@@ -53,7 +55,7 @@ def update_task_endpoint(task_id: UUID, data: TaskUpdate):
     - If no task matching id exists, raise HTTPException
     """
     logger.info("Updating task id=%s", str(task_id))
-    task = update_task(task_id, data)
+    task = update_task(task_id, data, user_id=current_user.id)
     if not task:
         logger.warning("Task not found for update id=%s", str(task_id))
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
@@ -62,14 +64,14 @@ def update_task_endpoint(task_id: UUID, data: TaskUpdate):
 
 
 @router.delete("/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_task_endpoint(task_id: UUID):
+def delete_task_endpoint(task_id: UUID, current_user: User = Depends(get_current_user)):
     """
     Delete a task endpoint.
     - Call task deletion method
     - If no task matching id exists, raise HTTPException
     """
     logger.info("Deleting task id=%s", str(task_id))
-    deleted = delete_task(task_id)
+    deleted = delete_task(task_id, user_id=current_user.id)
     if not deleted:
         logger.warning("Task not found for delete id=%s", str(task_id))
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")


### PR DESCRIPTION
## Summary
Enforce authentication on task endpoints make task endpoints user specific.

## Changes
- add auth on task endpoints
- specify task endpoints to current user's tasks

## Related Issues
Closes #23 #24 

## Testing
Describe how this was tested:
- [ ] Unit tests
- [x] Manual testing (curl / Swagger / Postman)
- [ ] Not tested (explain why)

## Notes / Tradeoffs
Optional: design decisions, limitations, or follow-up work.
