### PR TITLE
fix: hide owner ID from task responses

### DIFF
--- a/app/models/task.py
+++ b/app/models/task.py
@@ -115,6 +115,59 @@ class TaskUpdate(BaseModel):
         return due_date_value
 
 
+class TaskPublic(BaseModel):
+    id: UUID
+    title: str = Field(..., min_length=1, max_length=120)
+    description: Optional[str] = Field(None, max_length=400)
+    status: TaskStatus = TaskStatus.pending
+    due_date: Optional[datetime] = None
+    created_at: datetime
+    updated_at: datetime
+
+    @field_validator("title")
+    @classmethod
+    def title_must_not_be_blank(cls, title_value: str) -> str:
+        """
+        Verify that title is not blank.
+        - Strip whitespace
+        - If title is blank/empty raise ValueError
+        """
+        title_value = title_value.strip()
+        if not title_value:
+            raise ValueError("title cannot be empty")
+        return title_value
+    
+    @field_validator("description")
+    @classmethod
+    def description_strip_and_not_empty(cls, description_value: str | None) -> str | None:
+        """
+        Verify that description is not blank.
+        - Strip whitespace
+        - If description is blank/empty raise ValueError
+        """
+        if description_value is None:
+            return None
+        description_value = description_value.strip()
+        return description_value if description_value else None
+    
+    @field_validator("due_date")
+    @classmethod
+    def due_date_must_be_future_date_or_none(cls, due_date_value: datetime | None) -> datetime | None:
+        """
+        Verify that due_date is a future date.
+        - If due_date is None, return None
+        - If due_date is earlier than current datetime raise ValueError
+        """
+        if due_date_value is None:
+            return None
+        if due_date_value.tzinfo is None:
+            due_date_value = due_date_value.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        if due_date_value < now:
+            raise ValueError("due date must be a future date")
+        return due_date_value
+
+
 class Task(BaseModel):
     id: UUID
     owner_id: UUID

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -1,15 +1,15 @@
 from fastapi import APIRouter, HTTPException, Depends, status
-from app.models.task import Task, TaskCreate, TaskUpdate
+from app.models.task import TaskPublic, TaskCreate, TaskUpdate
 from app.models.user import User
 from app.auth.dependencies import get_current_user
-from app.storage.in_memory import list_tasks, create_task, get_task_by_id, update_task, delete_task
+from app.storage.in_memory import list_tasks, create_task, get_task_by_id_public, update_task, delete_task
 from uuid import UUID
 import logging
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
-@router.get("", response_model=list[Task])
+@router.get("", response_model=list[TaskPublic])
 def list_tasks_endpoint(current_user: User = Depends(get_current_user)):
     """
     Task listing endpoint.
@@ -19,7 +19,7 @@ def list_tasks_endpoint(current_user: User = Depends(get_current_user)):
     logger.info("Fetching tasks for user_id=%s", str(current_user.id))
     return list_tasks(user_id=current_user.id)
 
-@router.post("", status_code=status.HTTP_201_CREATED, response_model=Task)
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=TaskPublic)
 def create_task_endpoint(data: TaskCreate, current_user: User = Depends(get_current_user)):
     """
     Create new task endpoint.
@@ -31,7 +31,7 @@ def create_task_endpoint(data: TaskCreate, current_user: User = Depends(get_curr
     logger.info("Task created. id=%s", str(task.id))
     return task
 
-@router.get("/{task_id}", response_model=Task)
+@router.get("/{task_id}", response_model=TaskPublic)
 def get_task_by_id_endpoint(task_id: UUID, current_user: User = Depends(get_current_user)):
     """
     Fetch a task by id endpoint.
@@ -39,14 +39,14 @@ def get_task_by_id_endpoint(task_id: UUID, current_user: User = Depends(get_curr
     - Return task
     """
     logger.info("Fetching task id=%s", str(task_id))
-    task = get_task_by_id(task_id, user_id=current_user.id)
+    task = get_task_by_id_public(task_id, user_id=current_user.id)
     if not task:
         logger.warning("Task not found id=%s", str(task_id))
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
     return task
 
 
-@router.patch("/{task_id}", response_model=Task)
+@router.patch("/{task_id}", response_model=TaskPublic)
 def update_task_endpoint(task_id: UUID, data: TaskUpdate, current_user: User = Depends(get_current_user)):
     """
     Update an existing task endpoint.

--- a/app/storage/in_memory.py
+++ b/app/storage/in_memory.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional
 from uuid import UUID, uuid4
 from datetime import datetime, timezone
 
-from app.models.task import Task, TaskCreate, TaskUpdate
+from app.models.task import Task, TaskPublic, TaskCreate, TaskUpdate
 from app.models.user import User, UserPublic
 
 
@@ -13,7 +13,7 @@ from app.models.user import User, UserPublic
 tasks: Dict[str, Task] = {}
 
 
-def create_task(data: TaskCreate, user_id: UUID) -> Task:
+def create_task(data: TaskCreate, user_id: UUID) -> TaskPublic:
     """
     Create a new task.
     - Create new task instance
@@ -34,9 +34,25 @@ def create_task(data: TaskCreate, user_id: UUID) -> Task:
         updated_at=now,
     )
 
-    tasks[str(task_id)] = task
-    return task
+    task_public = get_task_public(task)
 
+    tasks[str(task_id)] = task
+    return task_public
+
+def get_task_public(task: Task) -> TaskPublic:
+    """
+    Return public version of a task (no owner id).
+    """
+    task_public = TaskPublic(
+        id=task.id,
+        title=task.title,
+        description=task.description,
+        status=task.status,
+        due_date=task.due_date,
+        created_at=task.created_at,
+        updated_at=task.updated_at,
+    )
+    return task_public
 
 def get_task_by_id(task_id: UUID, user_id: UUID) -> Optional[Task]:
     """
@@ -51,8 +67,21 @@ def get_task_by_id(task_id: UUID, user_id: UUID) -> Optional[Task]:
         return None
     return task
 
+def get_task_by_id_public(task_id: UUID, user_id: UUID) -> Optional[TaskPublic]:
+    """
+    Fetch a task by id.
+    - Return task if it exists
+    - Return None otherwise
+    """
+    task = tasks.get(str(task_id))
+    if not task:
+        return None
+    if task.owner_id != user_id:
+        return None
+    return get_task_public(task)
 
-def list_tasks(user_id: UUID) -> List[Task]:
+
+def list_tasks(user_id: UUID) -> List[TaskPublic]:
     """
     List all of the authenticated user's tasks.
     - Specific to user. Lists all tasks created by the authenticated user
@@ -60,11 +89,11 @@ def list_tasks(user_id: UUID) -> List[Task]:
     user_tasks = list()
     for task in tasks.values():
         if task.owner_id == user_id:
-            user_tasks.append(task)
+            user_tasks.append(get_task_public(task))
     return user_tasks
 
 
-def update_task(task_id: UUID, data: TaskUpdate, user_id: UUID) -> Optional[Task]:
+def update_task(task_id: UUID, data: TaskUpdate, user_id: UUID) -> Optional[TaskPublic]:
     """
     Update an existing task.
     - Fetch task by id
@@ -96,7 +125,7 @@ def update_task(task_id: UUID, data: TaskUpdate, user_id: UUID) -> Optional[Task
 
     if changed:
         task.updated_at = datetime.now(timezone.utc)
-    return task
+    return get_task_public(task)
 
 
 def delete_task(task_id: UUID, user_id: UUID) -> bool:


### PR DESCRIPTION
## Summary
Hide owner ID from task responses

## Changes
- add TaskPublic model which omits owner id
- modify storage methods to return TaskPublic instead of Task to API calls

## Related Issues
Closes #31 

## Testing
Describe how this was tested:
- [ ] Unit tests
- [x] Manual testing (curl / Swagger / Postman)
- [ ] Not tested (explain why)

## Notes / Tradeoffs
Optional: design decisions, limitations, or follow-up work.
