### PR TITLE
refactor: change implementation for hiding owner id from task responses

### DIFF
--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, Depends, status
 from app.models.task import TaskPublic, TaskCreate, TaskUpdate
 from app.models.user import User
 from app.auth.dependencies import get_current_user
-from app.storage.in_memory import list_tasks, create_task, get_task_by_id_public, update_task, delete_task
+from app.storage.in_memory import list_tasks, create_task, get_task_by_id, update_task, delete_task
 from uuid import UUID
 import logging
 
@@ -39,7 +39,7 @@ def get_task_by_id_endpoint(task_id: UUID, current_user: User = Depends(get_curr
     - Return task
     """
     logger.info("Fetching task id=%s", str(task_id))
-    task = get_task_by_id_public(task_id, user_id=current_user.id)
+    task = get_task_by_id(task_id, user_id=current_user.id)
     if not task:
         logger.warning("Task not found id=%s", str(task_id))
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")

--- a/app/storage/in_memory.py
+++ b/app/storage/in_memory.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional
 from uuid import UUID, uuid4
 from datetime import datetime, timezone
 
-from app.models.task import Task, TaskPublic, TaskCreate, TaskUpdate
+from app.models.task import Task, TaskCreate, TaskUpdate
 from app.models.user import User, UserPublic
 
 
@@ -13,7 +13,7 @@ from app.models.user import User, UserPublic
 tasks: Dict[str, Task] = {}
 
 
-def create_task(data: TaskCreate, user_id: UUID) -> TaskPublic:
+def create_task(data: TaskCreate, user_id: UUID) -> Task:
     """
     Create a new task.
     - Create new task instance
@@ -34,25 +34,9 @@ def create_task(data: TaskCreate, user_id: UUID) -> TaskPublic:
         updated_at=now,
     )
 
-    task_public = get_task_public(task)
-
     tasks[str(task_id)] = task
-    return task_public
+    return task
 
-def get_task_public(task: Task) -> TaskPublic:
-    """
-    Return public version of a task (no owner id).
-    """
-    task_public = TaskPublic(
-        id=task.id,
-        title=task.title,
-        description=task.description,
-        status=task.status,
-        due_date=task.due_date,
-        created_at=task.created_at,
-        updated_at=task.updated_at,
-    )
-    return task_public
 
 def get_task_by_id(task_id: UUID, user_id: UUID) -> Optional[Task]:
     """
@@ -67,21 +51,8 @@ def get_task_by_id(task_id: UUID, user_id: UUID) -> Optional[Task]:
         return None
     return task
 
-def get_task_by_id_public(task_id: UUID, user_id: UUID) -> Optional[TaskPublic]:
-    """
-    Fetch a task by id.
-    - Return task if it exists
-    - Return None otherwise
-    """
-    task = tasks.get(str(task_id))
-    if not task:
-        return None
-    if task.owner_id != user_id:
-        return None
-    return get_task_public(task)
 
-
-def list_tasks(user_id: UUID) -> List[TaskPublic]:
+def list_tasks(user_id: UUID) -> List[Task]:
     """
     List all of the authenticated user's tasks.
     - Specific to user. Lists all tasks created by the authenticated user
@@ -89,11 +60,11 @@ def list_tasks(user_id: UUID) -> List[TaskPublic]:
     user_tasks = list()
     for task in tasks.values():
         if task.owner_id == user_id:
-            user_tasks.append(get_task_public(task))
+            user_tasks.append(task)
     return user_tasks
 
 
-def update_task(task_id: UUID, data: TaskUpdate, user_id: UUID) -> Optional[TaskPublic]:
+def update_task(task_id: UUID, data: TaskUpdate, user_id: UUID) -> Optional[Task]:
     """
     Update an existing task.
     - Fetch task by id
@@ -125,7 +96,7 @@ def update_task(task_id: UUID, data: TaskUpdate, user_id: UUID) -> Optional[Task
 
     if changed:
         task.updated_at = datetime.now(timezone.utc)
-    return get_task_public(task)
+    return task
 
 
 def delete_task(task_id: UUID, user_id: UUID) -> bool:


### PR DESCRIPTION
## Summary
change implementation for hiding owner id from task responses

## Changes
- move owner id hiding to the API layer instead of storage
- storage layer returns Task object with owner id
- api layer returns task responses with no owner id

## Related Issues
Closes #33 

## Testing
Describe how this was tested:
- [ ] Unit tests
- [x] Manual testing (curl / Swagger / Postman)
- [ ] Not tested (explain why)

## Notes / Tradeoffs
Optional: design decisions, limitations, or follow-up work.
