### PR TITLE
feat: global slowapi and auth context middleware

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     CORS_ORIGINS: List[str] = Field(default_factory=lambda: ["http://localhost:3000"])
     ALLOWED_HOSTS: List[str] = Field(default_factory=lambda: ["localhost", "127.0.0.1"])
     
+    # Rate Limiting
+    RATE_LIMIT_ENABLED: bool = Field(default=True)
+    RATE_LIMIT_DEFAULT: str = Field(default="120/minute")
+    
     def get_log_level(self) -> int:
         """
         Convert Settings.LOG_LEVEL string to logging module constant.

--- a/app/main.py
+++ b/app/main.py
@@ -76,6 +76,16 @@ def create_app() -> FastAPI:
     # Error handling
     from app.core.errors import register_exception_handlers
     register_exception_handlers(app)
+    
+    # Auth context middleware (sets request.state.user_id)
+    from app.middleware.auth_context import AuthContextMiddleware
+    app.add_middleware(AuthContextMiddleware)
+    
+    # Rate limiting middleware
+    from slowapi.middleware import SlowAPIMiddleware
+    from app.core.rate_limit import limiter
+    app.state.limiter = limiter
+    app.add_middleware(SlowAPIMiddleware)
 
     # Routers
     app.include_router(health_endpoint_router)

--- a/app/middleware/auth_context.py
+++ b/app/middleware/auth_context.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+from app.auth.jwt import get_token_subject
+
+class AuthContextMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        request.state.user_id = None
+
+        auth = request.headers.get("Authorization")
+        if auth and auth.startswith("Bearer "):
+            token = auth.removeprefix("Bearer ").strip()
+            try:
+                request.state.user_id = get_token_subject(token)
+            except Exception:
+                pass # Token is invalid so will rate limit based on IP instead
+
+        return await call_next(request)


### PR DESCRIPTION
## Summary
Add auth context middleware, add rate limit settings, and wire middleware into main app during creation.

## Changes
- add auth context middleware (wire user_id into request state)
- add rate limit base settings with defaults into settings.py
- wire the middleware into the app on app creation

## Related Issues
Closes #65 

## Testing
Describe how this was tested:
- [ ] Unit tests
- [x] Manual testing (curl / Swagger / Postman)
- [ ] Not tested (explain why)

## Notes / Tradeoffs
Optional: design decisions, limitations, or follow-up work.
