### PR TITLE
fix: move db secrets to env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     image: postgres:16
     container_name: taskbeacon-db
     environment:
-      POSTGRES_DB: taskbeacon
-      POSTGRES_USER: taskbeacon
-      POSTGRES_PASSWORD: 3u8fKp9xT2mQ!
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - "7001:5432"
     volumes:


### PR DESCRIPTION
## Summary
fix: move db secrets to env

## Changes
- remove hard coded db secrets from docker-compose.yml
- modify secrets and supply them by env vars

## Related Issues
Closes #

## Testing
Describe how this was tested:
- [ ] Unit tests
- [x] Manual testing (curl / Swagger / Postman)
- [ ] Not tested (explain why)

## Notes / Tradeoffs
Optional: design decisions, limitations, or follow-up work.
